### PR TITLE
edit run-python(34).bat

### DIFF
--- a/run-python.bat
+++ b/run-python.bat
@@ -4,7 +4,7 @@ echo This script is able to start Miyamoto and/or download the
 echo latest spritedata and category data XMLs off of the internet.
 echo(
 echo Requirements:
-echo - Python 3.4, installed to the default location
+echo - Python 3+, installed to path (make sure the py command works)
 echo - PowerShell 3.0 (for the spritedata and categoryxml download), included
 echo   by default on Windows 10, for other versions of Windows,
 echo   you have to download the installer off of the internet.
@@ -22,7 +22,7 @@ goto :choice
 
 @echo OFF
 echo Downloading latest spritedata...
-powershell -Command "Invoke-WebRequest http://rhcafe.us.to/spritexml.php -OutFile miyamotodata/spritedata.xml"
+powershell -Command "Invoke-WebRequest https://raw.githubusercontent.com/Gota7/Miyamoto/master/miyamotodata/spritedata.xml -OutFile miyamotodata/spritedata.xml"
 echo Done!
 
 :nogoaway
@@ -35,12 +35,12 @@ goto :nogoaway
 
 @echo OFF
 echo Downloading latest cateogry data...
-powershell -Command "Invoke-WebRequest http://rhcafe.us.to/categoryxml.php -OutFile miyamotodata/spritecategories.xml"
+powershell -Command "Invoke-WebRequest https://raw.githubusercontent.com/Gota7/Miyamoto/master/miyamotodata/spritecategories.xml -OutFile miyamotodata/spritecategories.xml"
 echo Done!
 echo Starting Miyamoto!
-cmd /k C:/Python34/python.exe miyamoto.py
+cmd /k py miyamoto.py
 
 :srslygoaway
 @echo OFF
 echo Starting Miyamoto!
-cmd /k C:/Python34/python.exe miyamoto.py
+cmd /k py miyamoto.py

--- a/run-python.bat
+++ b/run-python.bat
@@ -39,6 +39,7 @@ powershell -Command "Invoke-WebRequest https://raw.githubusercontent.com/Gota7/M
 echo Done!
 echo Starting Miyamoto!
 py miyamoto.py
+EXIT
 
 :srslygoaway
 @echo OFF

--- a/run-python.bat
+++ b/run-python.bat
@@ -38,9 +38,9 @@ echo Downloading latest cateogry data...
 powershell -Command "Invoke-WebRequest https://raw.githubusercontent.com/Gota7/Miyamoto/master/miyamotodata/spritecategories.xml -OutFile miyamotodata/spritecategories.xml"
 echo Done!
 echo Starting Miyamoto!
-cmd /k py miyamoto.py
+py miyamoto.py
 
 :srslygoaway
 @echo OFF
 echo Starting Miyamoto!
-cmd /k py miyamoto.py
+py miyamoto.py


### PR DESCRIPTION
It works. Yeah!

Things I fixed:

1. If you download sprite categories Miyamoto! will run twice.

2. The links to rhcafe.us.to may not work in the near future (the one to download spritecategories.xml already leads to a 404 error.)

3. CMD doesn't work to load Python, it just loads the command prompt again.

4. It only works on Python 3.4, not 3.8 or 4.0 or whatever comes in the future, and it's a fixed path to Python.

Sorry for the three commits, I realized things as I went and edited the file.